### PR TITLE
PR : DocList 너비 조절 기능 및 Sidebar 수납 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"react-motion": "^0.5.2",
 		"react-nice-dates": "^3.1.0",
 		"react-redux": "^7.2.4",
+		"react-rnd": "^10.3.4",
 		"react-router-dom": "^5.2.0",
 		"react-scripts": "4.0.3",
 		"redux": "^4.1.0",

--- a/src/components/ResizeWidth.jsx
+++ b/src/components/ResizeWidth.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Rnd } from "react-rnd";
+import { useDispatch } from "react-redux";
+
+// initialSize = {width: "260px", height: "100%"}
+// drag : "right" or "left"
+// option : min·max Width/Height
+// storeSaveFunc : dispatch할 actionCreator
+const ResizeWidth = ({
+  size,
+  handleSize,
+  drag,
+  option,
+  storeSaveFunc,
+  children,
+}) => {
+  const dispatch = useDispatch();
+
+  const onResize = (event, dir, refToElement, delta, position) => {
+    handleSize(refToElement.style.width.split("px")[0]);
+  };
+
+  const onResizeStop = (event) => {
+    dispatch(storeSaveFunc(size.width));
+  };
+
+  return (
+    <Rnd
+      default={{
+        x: drag === "right" ? 0 : null, // left 일 때 추가 필요
+        y: 0,
+        width: size.width,
+        height: size.height,
+      }}
+      resizeGrid={[1, 1]}
+      disableDragging={true}
+      bounds="window"
+      enableResizing={{
+        top: false,
+        bottom: false,
+        right: drag === "right" ? true : false,
+        left: drag === "left",
+      }}
+      onResize={onResize}
+      onResizeStop={onResizeStop}
+      style={{ zIndex: 25 }} // var가 안됨
+      {...option}
+    >
+      {children}
+    </Rnd>
+  );
+};
+
+export default ResizeWidth;

--- a/src/components/WSSidebar.jsx/Notice.jsx
+++ b/src/components/WSSidebar.jsx/Notice.jsx
@@ -5,10 +5,10 @@ import Icon from "../Icon";
 import { IconBtn, Text } from "../../elem";
 import flex from "../../themes/flex";
 
-const Notice = () => {
+const Notice = ({ _onClick }) => {
   return (
     <NotiContainer>
-      <IconBox>
+      <IconBox onClick={_onClick}>
         <Icon icon="bookmark" size="20px" color="var(--main)" />
       </IconBox>
       <NotiText type="body_3">8월 14일 발표까지 MVP 전부 만들기!!!!!!</NotiText>

--- a/src/components/WSSidebar.jsx/WSSidebar.jsx
+++ b/src/components/WSSidebar.jsx/WSSidebar.jsx
@@ -4,14 +4,31 @@ import styled from "styled-components";
 import Notice from "./Notice";
 import RoomMember from "./RoomMember";
 import Chat from "../../feature/chat/Chat";
+import { IconBtn } from "../../elem";
+import Icon from "../Icon";
+import { useDispatch, useSelector } from "react-redux";
+import { showSidebar } from "../../redux/modules/resize";
 
 const WSSidebar = () => {
+  const dispatch = useDispatch();
+
+  const isShowSidebar = useSelector((state) => state.resize.isShowSidebar);
+
+  const handleSidebar = () => dispatch(showSidebar());
+
   return (
-    <Container>
-      <Notice />
-      <RoomMember />
-      <Chat />
-    </Container>
+    <>
+      <Container sidebar={isShowSidebar}>
+        <Notice _onClick={handleSidebar} />
+        <RoomMember />
+        <Chat />
+      </Container>
+      {!isShowSidebar && (
+        <IconBox _onClick={handleSidebar}>
+          <Icon icon="arrow-down" size="20px" color="var(--white)" />
+        </IconBox>
+      )}
+    </>
   );
 };
 
@@ -21,13 +38,26 @@ const Container = styled.aside`
 
   position: fixed;
   top: 48px;
-  right: 0;
+  right: ${(props) => (props.sidebar ? 0 : `-280px;`)};
   flex-shrink: 0;
   flex-grow: 0;
+  z-index: var(--indexSidebar);
   width: 260px;
   height: calc(100vh - var(--minusHeight));
   border-left: 1px solid var(--line);
   background-color: var(--white);
+  transition: right 500ms ease-in-out;
+`;
+
+const IconBox = styled(IconBtn)`
+  position: fixed;
+  top: 50vh;
+  right: 10px;
+  border-radius: 50%;
+  transform: rotate(90deg);
+  z-index: 20;
+  transition: display 500ms ease-in-out;
+  transition-delay: 2s;
 `;
 
 export default WSSidebar;

--- a/src/feature/document/DocList.jsx
+++ b/src/feature/document/DocList.jsx
@@ -38,10 +38,10 @@ const DocList = ({ docList }) => {
 };
 
 const Container = styled.aside`
-  --WSHeaderHeight: 48px;
-  width: 260px;
-  max-height: calc(100vh - var(--WSHeaderHeight) + 20px);
+  width: 100%;
+  max-height: 100%;
   border-right: 1px solid var(--line);
+  background-color: var(--white);
 `;
 
 const TitleBox = styled.div`

--- a/src/feature/document/DocViewer.jsx
+++ b/src/feature/document/DocViewer.jsx
@@ -14,7 +14,7 @@ import { body_4 } from "../../themes/textStyle";
 import flex from "../../themes/flex";
 import MarkDownViewer from "../../components/MarkDownViewer";
 
-const DocViewer = () => {
+const DocViewer = ({ left }) => {
   const history = useHistory();
   const { roomId, docId } = useParams();
 
@@ -78,7 +78,7 @@ const DocViewer = () => {
   };
 
   return (
-    <Container>
+    <Container left={left}>
       <ViewerHeader>
         <TitleBox>
           <Title type="head_4">{current.title}</Title>
@@ -101,15 +101,17 @@ const DocViewer = () => {
   );
 };
 
-// 임시 스타일
 const Container = styled.section`
   --header: 48px;
   --minusHeight: calc(var(--header));
 
+  position: relative;
+  top: 0;
+  left: ${(props) => `${props.left}px;`};
   display: flex;
-  width: 100%;
-  min-height: calc(100vh - var(--minusHeight));
   flex-direction: column;
+  width: ${(props) => `calc(100% - ${props.left}px)`};
+  min-height: calc(100vh - var(--minusHeight));
   width: calc(100% - 260px);
   padding: var(--smMargin);
 `;

--- a/src/pages/DocView.jsx
+++ b/src/pages/DocView.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
+import { Rnd } from "react-rnd";
 
 // component
 import DocList from "../feature/document/DocList";
@@ -9,21 +10,59 @@ import DocViewer from "../feature/document/DocViewer";
 
 // redux & api
 import { __getDocs } from "../redux/modules/document";
+import { resizeDocList } from "../redux/modules/resize";
 
 const DocView = (props) => {
   const { roomId } = useParams();
   const dispatch = useDispatch();
 
   const docList = useSelector((state) => state.document.docList) || [];
+  const docListWidth = useSelector((state) => state.resize.docListWidth);
+
+  const [size, setSize] = useState({
+    width: docListWidth,
+    height: "calc(100vh - 48px + 20px)",
+  });
 
   useEffect(() => {
     dispatch(__getDocs(roomId));
   }, [dispatch, roomId]);
 
+  const onResize = (event, dir, refToElement, delta, position) => {
+    setSize((pre) => ({
+      ...pre,
+      width: refToElement.style.width.split("px")[0],
+    }));
+  };
+
+  const onResizeStop = (event) => {
+    dispatch(resizeDocList(size.width));
+  };
+
   return (
     <Container>
-      <DocList docList={docList} />
-      <DocViewer />
+      {size.width && (
+        <Rnd
+          default={{
+            x: 0,
+            y: 0,
+            width: size.width,
+          }}
+          minWidth="260px"
+          maxWidth="500px"
+          minHeight="100vh"
+          maxHeight="100vh"
+          resizeGrid={[1, 1]}
+          disableDragging={true}
+          bounds="window"
+          enableResizing={{ top: false, bottom: false, right: true }}
+          onResize={onResize}
+          onResizeStop={onResizeStop}
+        >
+          <DocList docList={docList} />
+        </Rnd>
+      )}
+      <DocViewer left={size.width} />
     </Container>
   );
 };

--- a/src/pages/DocView.jsx
+++ b/src/pages/DocView.jsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import { Rnd } from "react-rnd";
 
 // component
 import DocList from "../feature/document/DocList";
 import DocViewer from "../feature/document/DocViewer";
+import ResizeWidth from "../components/ResizeWidth";
 
 // redux & api
 import { __getDocs } from "../redux/modules/document";
@@ -19,55 +19,44 @@ const DocView = (props) => {
   const docList = useSelector((state) => state.document.docList) || [];
   const docListWidth = useSelector((state) => state.resize.docListWidth);
 
+  useEffect(() => {
+    dispatch(__getDocs(roomId));
+  }, [dispatch, roomId]);
+
+  // 아래 내용들은 모두 ResizeWidth 관련
   const [size, setSize] = useState({
     width: docListWidth,
     height: "calc(100vh - 48px + 20px)",
   });
 
-  useEffect(() => {
-    dispatch(__getDocs(roomId));
-  }, [dispatch, roomId]);
-
-  const onResize = (event, dir, refToElement, delta, position) => {
-    setSize((pre) => ({
-      ...pre,
-      width: refToElement.style.width.split("px")[0],
-    }));
+  const option = {
+    minWidth: "260px",
+    maxWidth: "500px",
   };
 
-  const onResizeStop = (event) => {
-    dispatch(resizeDocList(size.width));
-  };
+  const handleSize = useCallback(
+    (width) => setSize((pre) => ({ ...pre, width })),
+    []
+  );
 
   return (
     <Container>
-      {size.width && (
-        <Rnd
-          default={{
-            x: 0,
-            y: 0,
-            width: size.width,
-          }}
-          minWidth="260px"
-          maxWidth="500px"
-          minHeight="100vh"
-          maxHeight="100vh"
-          resizeGrid={[1, 1]}
-          disableDragging={true}
-          bounds="window"
-          enableResizing={{ top: false, bottom: false, right: true }}
-          onResize={onResize}
-          onResizeStop={onResizeStop}
+      {
+        <ResizeWidth
+          size={size}
+          handleSize={handleSize}
+          drag="right"
+          option={option}
+          storeSaveFunc={resizeDocList}
         >
           <DocList docList={docList} />
-        </Rnd>
-      )}
+        </ResizeWidth>
+      }
       <DocViewer left={size.width} />
     </Container>
   );
 };
 
-// 임시 스타일
 const Container = styled.section`
   display: flex;
   width: 100%;

--- a/src/redux/configStore.js
+++ b/src/redux/configStore.js
@@ -14,6 +14,7 @@ import todos from "./modules/todos";
 import member from "./modules/member";
 import dashBoard from "./modules/dashBoard";
 import chat from "./modules/chat";
+import resize from "./modules/resize";
 
 // middlewares
 import thunk from "redux-thunk";
@@ -35,6 +36,7 @@ const appReducer = combineReducers({
   date,
   calendar,
   chat,
+  resize,
   router: connectRouter(history),
 });
 

--- a/src/redux/modules/resize.js
+++ b/src/redux/modules/resize.js
@@ -3,15 +3,18 @@ import produce from "immer";
 
 // action type
 const RESIZE_DOCLIST = "resize/RESIZE_DOCLIST";
+const SHOW_SIDEBAR = "resize/SHOW_SIDEBAR";
 
 // action creator;
 export const resizeDocList = createAction(RESIZE_DOCLIST, (width) => ({
   width,
 }));
+export const showSidebar = createAction(SHOW_SIDEBAR);
 
 // initialState
 const initialState = {
   docListWidth: 260,
+  isShowSidebar: false,
 };
 
 // reducer
@@ -20,6 +23,10 @@ const resize = handleActions(
     [RESIZE_DOCLIST]: (state, action) =>
       produce(state, (draft) => {
         draft.docListWidth = action.payload.width;
+      }),
+    [SHOW_SIDEBAR]: (state, action) =>
+      produce(state, (draft) => {
+        draft.isShowSidebar = !state.isShowSidebar;
       }),
   },
   initialState

--- a/src/redux/modules/resize.js
+++ b/src/redux/modules/resize.js
@@ -1,0 +1,28 @@
+import { createAction, handleActions } from "redux-actions";
+import produce from "immer";
+
+// action type
+const RESIZE_DOCLIST = "resize/RESIZE_DOCLIST";
+
+// action creator;
+export const resizeDocList = createAction(RESIZE_DOCLIST, (width) => ({
+  width,
+}));
+
+// initialState
+const initialState = {
+  docListWidth: 260,
+};
+
+// reducer
+const resize = handleActions(
+  {
+    [RESIZE_DOCLIST]: (state, action) =>
+      produce(state, (draft) => {
+        draft.docListWidth = action.payload.width;
+      }),
+  },
+  initialState
+);
+
+export default resize;

--- a/src/shared/GlobalStyles.js
+++ b/src/shared/GlobalStyles.js
@@ -17,6 +17,7 @@ const GlobalStyles = createGlobalStyle`
 		--notice : #ff7776;
 
 		/* z-index */
+		--indesSidebar : 25;
 		--indexColorPicker: 32;
 		--indexHeader : 30;
 		--indexDrop : 35;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,7 +3486,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -5242,6 +5242,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-memoize@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
 fastq@^1.6.0:
   version "1.11.1"
@@ -9313,7 +9318,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9547,6 +9552,13 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+re-resizable@6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.0.tgz#9c3059b389ced6ade602234cc5bb1e12d231cd47"
+  integrity sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==
+  dependencies:
+    fast-memoize "^2.5.1"
+
 react-app-polyfill@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz#a0bea50f078b8a082970a9d853dc34b6dcc6a3cf"
@@ -9627,6 +9639,14 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-draggable@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
@@ -9699,6 +9719,15 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-rnd@^10.3.4:
+  version "10.3.4"
+  resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-10.3.4.tgz#1039ac93cb6a6f02f1246883c970b7c4481765d2"
+  integrity sha512-IVNEVB8+JD+QjBs2q7d4mRduj5ooG51UAS4FY15x8v3KhkpQ300ywRkgdIftcDKfkALYUjmaHZg3iCH2/WTaYQ==
+  dependencies:
+    re-resizable "6.9.0"
+    react-draggable "4.4.3"
+    tslib "2.2.0"
 
 react-router-dom@^5.2.0:
   version "5.2.0"
@@ -11387,6 +11416,11 @@ tsconfig-paths@^3.9.0:
     json5 "^2.2.0"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
- DocList 너비 조절 기능
  - react-rnd 이용

- Sidebar 수납 기능
  - transition이용

둘 다 리덕스 모듈 사용 
이유 : 적어도 이 워크스페이스 안에서 (새로고침 하지 않는 한) 같은 너비의 사이드바, DocList를 보여주기 위함